### PR TITLE
fix: make package.json#main point to a correct file

### DIFF
--- a/.changeset/small-feet-brake.md
+++ b/.changeset/small-feet-brake.md
@@ -1,0 +1,5 @@
+---
+"astrojs-compiler-sync": patch
+---
+
+fix: make package.json#main point to a correct file

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "astrojs-compiler-sync",
   "version": "0.3.3",
   "description": "@astrojs/compiler to process synchronously.",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs",
   "files": [
     "lib",
     "browser"


### PR DESCRIPTION
This was causing environments that don't support conditional exports (Jest, eslint-plugin-import, ...) to break, being a blocker at https://github.com/graphql/graphiql/pull/3475