### PR TITLE
fix: fix .d.ts resolution for moduleResolution: node

### DIFF
--- a/.changeset/shy-snakes-promise.md
+++ b/.changeset/shy-snakes-promise.md
@@ -1,0 +1,5 @@
+---
+"astrojs-compiler-sync": patch
+---
+
+fix: fix .d.ts resolution for moduleResolution: node

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.4",
   "description": "@astrojs/compiler to process synchronously.",
   "main": "lib/index.cjs",
+  "types": "lib/index.d.ts",
   "files": [
     "lib",
     "browser"


### PR DESCRIPTION
Followup to #44, since it broke .d.ts resolution on `moduleResolution: node`.
It was because TS started to look at corresponding `.d.ts` to `lib/index.cjs`, which should be `lib/index.d.cts` but that doesn't exist.