### PR TITLE
feat: prefer native `@astrojs/compiler/sync` when available

### DIFF
--- a/.changeset/itchy-pandas-speak.md
+++ b/.changeset/itchy-pandas-speak.md
@@ -1,0 +1,5 @@
+---
+"astrojs-compiler-sync": minor
+---
+
+feat: prefer native `@astrojs/compiler/sync` when available

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 21.x, 22.x]
+        astro-version: [0.x, 1.3.0, 1.x, 2.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -29,5 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Packages
         run: npm install -f
+      - name: Install @astrojs/compiler ${{ matrix.astro-version }}
+        run: npm install -D @astrojs/compiler@${{ matrix.astro-version }}
       - name: Test
         run: npm test

--- a/lib/compiler-sync.cjs
+++ b/lib/compiler-sync.cjs
@@ -1,0 +1,26 @@
+"use strict";
+
+const { createSyncFn } = require("synckit");
+const nativeCompiler = require("./native-compiler.cjs");
+
+let workerSync;
+
+function createCompilerSync(workerPath) {
+  return function compilerSync(method, ...args) {
+    if (
+      // https://github.com/withastro/compiler/issues/911#issuecomment-1861624633
+      method !== "transform" &&
+      typeof nativeCompiler?.[method] === "function"
+    ) {
+      return nativeCompiler[method](...args);
+    }
+
+    if (!workerSync) {
+      workerSync = createSyncFn(workerPath, 3000);
+    }
+
+    return workerSync(method, ...args);
+  };
+}
+
+module.exports = createCompilerSync;

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -1,10 +1,9 @@
 "use strict";
 
-const { createSyncFn } = require("synckit");
+const createCompilerSync = require("./compiler-sync.cjs");
 
-const compilerSync = createSyncFn(
+const compilerSync = createCompilerSync(
   require.resolve("./astrojs-compiler-worker.js"),
-  3000,
 );
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
-import { createSyncFn } from "synckit";
+import createCompilerSync from "./compiler-sync.cjs";
 
-const compilerSync = createSyncFn(
-  new URL("./astrojs-compiler-worker.js", import.meta.url),
-  3000,
-);
+const workerPath = new URL("./astrojs-compiler-worker.js", import.meta.url);
+
+const compilerSync = createCompilerSync(workerPath);
 
 export function parse(...args) {
   return compilerSync("parse", ...args);

--- a/lib/native-compiler.cjs
+++ b/lib/native-compiler.cjs
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * @import * as compiler from '@astrojs/compiler/sync'
+ */
+
+const { createRequire } = require("node:module");
+const { pathToFileURL } = require("node:url");
+
+const cjsRrequire =
+  typeof require === "undefined"
+    ? createRequire(pathToFileURL(__filename))
+    : require;
+
+/**
+ * @type {typeof compiler | undefined}
+ */
+let nativeCompiler;
+
+try {
+  nativeCompiler = cjsRrequire("@astrojs/compiler/sync");
+} catch {
+  //
+}
+
+module.exports = nativeCompiler;


### PR DESCRIPTION
close #71

The native sync doesn't work for `transform` method.

See also https://github.com/withastro/compiler/issues/911#issuecomment-1861624633

cc @ota-meshi 